### PR TITLE
Bump to duckdb 1.5.3.  

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build extension binaries
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.5-variegata
     with:
-      duckdb_version: v1.5.2
+      duckdb_version: v1.5.3
       ci_tools_version: v1.5-variegata
       extension_name: duckdb_geoip_rs
       extra_toolchains: rust;python3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "duckdb"
-version = "1.10502.0"
+version = "1.10503.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdc796383b176dd5a45353fbb5e64583c0ee4da12cb62c9e510b785324b2488"
+checksum = "3b7f81a3dcbd677458ff30b1047b02951282f1e189260db07e60e0890b3b64bc"
 dependencies = [
  "arrow",
  "cast",
@@ -536,9 +536,9 @@ dependencies = [
 
 [[package]]
 name = "duckdb-loadable-macros"
-version = "1.10502.0"
+version = "1.10503.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c15036a8d19f31f53acef09ff910c96cff5fe9b5d8f59e6dc90e7b836e09b20"
+checksum = "040d62f60360b1b933b02d59615bb5ff43489f09d1e5df80a3959689e01b7e8f"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -548,10 +548,10 @@ dependencies = [
 
 [[package]]
 name = "duckdb_geoip_rs"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
+ "arrow",
  "duckdb",
- "libduckdb-sys",
  "maxminddb",
  "once_cell",
 ]
@@ -1113,9 +1113,9 @@ checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libduckdb-sys"
-version = "1.10502.0"
+version = "1.10503.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7401630ae2abcff642f7156294289e50f2d222e061c026ad797b01bf20c215"
+checksum = "f3a3cc4e8aa9cc1943ab2a5154e47564ba6e7598001cc148d2bb5fc63f078b58"
 dependencies = [
  "flate2",
  "pkg-config",
@@ -1188,9 +1188,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "maxminddb"
-version = "0.27.3"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76371bd37ce742f8954daabd0fde7f1594ee43ac2200e20c003ba5c3d65e2192"
+checksum = "faf6467428ad055b71e588bcedcbaf2ff605b3251deb0c52be4a04b674c546dd"
 dependencies = [
  "ipnetwork",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "duckdb_geoip_rs"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 
 [lib]
@@ -20,8 +20,8 @@ path = "src/wasm_lib.rs"
 crate-type = ["staticlib"]
 
 [dependencies]
-duckdb = { version = "=1.10502.0", features = ["vscalar", "loadable-extension"] }
-libduckdb-sys = { version = "=1.10502.0", features = ["loadable-extension"] }
+duckdb = { version = "=1.10503.0", features = ["vscalar", "loadable-extension", "vscalar-arrow"] }
+arrow = { version = "58", default-features = false }
 
-maxminddb = { version = "0.27.3", features = ["mmap"] }
+maxminddb = { version = "0.28.1", features = ["mmap"] }
 once_cell = "1.21.3"

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ EXTENSION_NAME=duckdb_geoip_rs
 USE_UNSTABLE_C_API=1
 
 # Target DuckDB version
-TARGET_DUCKDB_VERSION=v1.5.2
+TARGET_DUCKDB_VERSION=v1.5.3
 export MAXMIND_MMDB_DIR = $(CURDIR)/test_db
 
 all: configure debug

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DuckDB geoip extension
 
-This extension export 4 function using MaxminDB database:
+This extension export 4 function using MaxminDB database that can be used with DuckDB.
 * geoip_asn_org(ip : VARCHAR)-> VARCHAR
 * geoip_asn_num(ip : VARCHAR)-> VARCHAR
 * geoip_city(ip : VARCHAR)-> VARCHAR
@@ -42,13 +42,18 @@ SELECT ip, geoip_asn_org(ip),geoip_asn_num(ip),geoip_city(ip), geoip_country_iso
 │     ip     │ geoip_asn_org(ip) │ geoip_asn_num(ip) │ geoip_city(ip) │ geoip_country_iso(ip) │
 │  varchar   │      varchar      │      varchar      │    varchar     │        varchar        │
 ├────────────┼───────────────────┼───────────────────┼────────────────┼───────────────────────┤
-│ 1.1.1.1    │ CLOUDFLARENET     │ 13335             │                │                       │
-│ 8.8.8.8    │ GOOGLE            │ 15169             │                │ US                    │
-│ 80.8.8.8   │ Orange            │ 3215              │                │ RE                    │
+│ 1.1.1.1    │ Cloudflare, Inc.  │ 13335             │                │ AU                    │
+│ 8.8.8.8    │ Google LLC        │ 15169             │                │ US                    │
+│ 80.8.8.8   │ Orange            │ 3215              │ Le Tampon      │ RE                    │
 │ 90.9.250.1 │ Orange            │ 3215              │ Lyon           │ FR                    │
-│ not_anip   │                   │                   │                │                       │
+│ not_anip   │ NULL              │ NULL              │ NULL           │ NULL                  │
 └────────────┴───────────────────┴───────────────────┴────────────────┴───────────────────────┘
 ```
+
+## Project status
+
+The source code is open-source; external contributions are accepted but not actively pursued.
+I don’t plan to add any new features, but simply to keep this plugin up to date with new versions of DuckDB.
 
 ## Cloning
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,19 +1,22 @@
-use duckdb::core::FlatVector;
 use duckdb::{
-    core::{DataChunkHandle, Inserter, LogicalTypeId},
     duckdb_entrypoint_c_api,
-    types::DuckString,
-    vscalar::{ScalarFunctionSignature, VScalar},
-    vtab::arrow::WritableVector,
+    vscalar::{ArrowFunctionSignature, VArrowScalar},
     Connection, Result,
 };
-use libduckdb_sys as ffi;
+
+use arrow::{
+    array::{Array, StringArray},
+    datatypes::DataType,
+    record_batch::RecordBatch,
+};
 use maxminddb::geoip2;
 use maxminddb::Mmap;
 use once_cell::sync::OnceCell;
 use std::env;
 use std::error::Error;
+use std::net::IpAddr;
 use std::path::Path;
+use std::sync::Arc;
 
 enum MMDBDatabaseType {
     City,
@@ -47,60 +50,44 @@ static MMDB_CITY_CELL: OnceCell<maxminddb::Reader<Mmap>> = OnceCell::new();
 
 fn invoke_wrapper(
     mmdb_type: MMDBDatabaseType,
-    input: &mut DataChunkHandle,
-    output: &mut dyn WritableVector,
-    geoip_func: fn(db: &maxminddb::Reader<Mmap>, ip: String) -> Option<String>,
-) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    input: RecordBatch,
+    geoip_func: fn(db: &maxminddb::Reader<Mmap>, ip: IpAddr) -> Option<String>,
+) -> Result<Arc<dyn Array>, Box<dyn Error>> {
     let reader = match mmdb_type {
         MMDBDatabaseType::City => MMDB_CITY_CELL.get_or_init(|| mmdb_type.get_db()),
         MMDBDatabaseType::Asn => MMDB_ASN_CELL.get_or_init(|| mmdb_type.get_db()),
     };
-    let mut input_vector = input.flat_vector(0);
-    let sliced_input_vector: &mut [ffi::duckdb_string_t] = input_vector.as_mut_slice();
-    let output_vector: FlatVector = output.flat_vector();
-
-    let count: usize = input.len();
-    for i in 0..count {
-        let input_str = sliced_input_vector.get_mut(i);
-        match { input_str } {
-            None => {
-                output_vector.insert(i, "");
-            }
-            Some(s) => {
-                let ip_addr: String = DuckString::new(s).as_str().to_string();
-                output_vector.insert(
-                    i,
-                    geoip_func(reader, ip_addr)
-                        .unwrap_or_else(|| "".to_string())
-                        .as_str(),
-                );
-            }
-        }
-    }
-    Ok(())
+    let input_vector = input
+        .column(0)
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .unwrap();
+    let results: Vec<Option<String>> = input_vector
+        .iter()
+        .map(|i| -> Result<Option<String>, Box<dyn Error>> {
+            Ok(i.and_then(|input_str| {
+                input_str
+                    .parse()
+                    .ok()
+                    .and_then(|as_ip| Some(geoip_func(reader, as_ip).unwrap_or("".to_string())))
+            }))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(Arc::new(StringArray::from(results)))
 }
 
 pub struct GeoipAsnOrgScalar {}
-impl VScalar for GeoipAsnOrgScalar {
+impl VArrowScalar for GeoipAsnOrgScalar {
     type State = ();
 
-    unsafe fn invoke(
-        _state: &Self::State,
-        input: &mut DataChunkHandle,
-        output: &mut dyn WritableVector,
-    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
-        invoke_wrapper(
-            MMDBDatabaseType::Asn,
-            input,
-            output,
-            GeoipAsnOrgScalar::lookup_ip,
-        )
+    fn invoke(_: &Self::State, input: RecordBatch) -> Result<Arc<dyn Array>, Box<dyn Error>> {
+        invoke_wrapper(MMDBDatabaseType::Asn, input, GeoipAsnOrgScalar::lookup_ip)
     }
 
-    fn signatures() -> Vec<ScalarFunctionSignature> {
-        vec![ScalarFunctionSignature::exact(
-            vec![LogicalTypeId::Varchar.into()],
-            LogicalTypeId::Varchar.into(),
+    fn signatures() -> Vec<ArrowFunctionSignature> {
+        vec![ArrowFunctionSignature::exact(
+            vec![DataType::Utf8],
+            DataType::Utf8,
         )]
     }
 
@@ -110,9 +97,9 @@ impl VScalar for GeoipAsnOrgScalar {
 }
 
 impl GeoipAsnOrgScalar {
-    fn lookup_ip(db: &maxminddb::Reader<Mmap>, ip: String) -> Option<String> {
+    fn lookup_ip(db: &maxminddb::Reader<Mmap>, ip: IpAddr) -> Option<String> {
         //let as_str = ip_as_ref.data.as_ref()?;
-        db.lookup(ip.parse().ok()?)
+        db.lookup(ip)
             .ok()
             .and_then(|result| result.decode::<geoip2::Asn>().ok())?
             .and_then(|asn_record| asn_record.autonomous_system_organization)
@@ -121,26 +108,17 @@ impl GeoipAsnOrgScalar {
 }
 
 pub struct GeoipAsnNumScalar {}
-impl VScalar for GeoipAsnNumScalar {
+impl VArrowScalar for GeoipAsnNumScalar {
     type State = ();
 
-    unsafe fn invoke(
-        _state: &Self::State,
-        input: &mut DataChunkHandle,
-        output: &mut dyn WritableVector,
-    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
-        invoke_wrapper(
-            MMDBDatabaseType::Asn,
-            input,
-            output,
-            GeoipAsnNumScalar::lookup_ip,
-        )
+    fn invoke(_: &Self::State, input: RecordBatch) -> Result<Arc<dyn Array>, Box<dyn Error>> {
+        invoke_wrapper(MMDBDatabaseType::Asn, input, GeoipAsnNumScalar::lookup_ip)
     }
 
-    fn signatures() -> Vec<ScalarFunctionSignature> {
-        vec![ScalarFunctionSignature::exact(
-            vec![LogicalTypeId::Varchar.into()],
-            LogicalTypeId::Varchar.into(),
+    fn signatures() -> Vec<ArrowFunctionSignature> {
+        vec![ArrowFunctionSignature::exact(
+            vec![DataType::Utf8],
+            DataType::Utf8,
         )]
     }
 
@@ -150,8 +128,8 @@ impl VScalar for GeoipAsnNumScalar {
 }
 
 impl GeoipAsnNumScalar {
-    fn lookup_ip(db: &maxminddb::Reader<Mmap>, ip: String) -> Option<String> {
-        db.lookup(ip.parse().ok()?)
+    fn lookup_ip(db: &maxminddb::Reader<Mmap>, ip: IpAddr) -> Option<String> {
+        db.lookup(ip)
             .ok()
             .and_then(|result| result.decode::<geoip2::Asn>().ok())?
             .and_then(|asn_record| asn_record.autonomous_system_number)
@@ -160,26 +138,17 @@ impl GeoipAsnNumScalar {
 }
 
 pub struct GeoipCityScalar {}
-impl VScalar for GeoipCityScalar {
+impl VArrowScalar for GeoipCityScalar {
     type State = ();
 
-    unsafe fn invoke(
-        _state: &Self::State,
-        input: &mut DataChunkHandle,
-        output: &mut dyn WritableVector,
-    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
-        invoke_wrapper(
-            MMDBDatabaseType::City,
-            input,
-            output,
-            GeoipCityScalar::lookup_ip,
-        )
+    fn invoke(_: &Self::State, input: RecordBatch) -> Result<Arc<dyn Array>, Box<dyn Error>> {
+        invoke_wrapper(MMDBDatabaseType::City, input, GeoipCityScalar::lookup_ip)
     }
 
-    fn signatures() -> Vec<ScalarFunctionSignature> {
-        vec![ScalarFunctionSignature::exact(
-            vec![LogicalTypeId::Varchar.into()],
-            LogicalTypeId::Varchar.into(),
+    fn signatures() -> Vec<ArrowFunctionSignature> {
+        vec![ArrowFunctionSignature::exact(
+            vec![DataType::Utf8],
+            DataType::Utf8,
         )]
     }
 
@@ -189,9 +158,9 @@ impl VScalar for GeoipCityScalar {
 }
 
 impl GeoipCityScalar {
-    fn lookup_ip(db: &maxminddb::Reader<Mmap>, ip: String) -> Option<String> {
+    fn lookup_ip(db: &maxminddb::Reader<Mmap>, ip: IpAddr) -> Option<String> {
         match db
-            .lookup(ip.parse().ok()?)
+            .lookup(ip)
             .ok()
             .and_then(|result| result.decode::<geoip2::City>().ok())?
         {
@@ -203,26 +172,21 @@ impl GeoipCityScalar {
 }
 
 pub struct GeoipCountryIsoScalar {}
-impl VScalar for GeoipCountryIsoScalar {
+impl VArrowScalar for GeoipCountryIsoScalar {
     type State = ();
 
-    unsafe fn invoke(
-        _state: &Self::State,
-        input: &mut DataChunkHandle,
-        output: &mut dyn WritableVector,
-    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+    fn invoke(_: &Self::State, input: RecordBatch) -> Result<Arc<dyn Array>, Box<dyn Error>> {
         invoke_wrapper(
             MMDBDatabaseType::City,
             input,
-            output,
             GeoipCountryIsoScalar::lookup_ip,
         )
     }
 
-    fn signatures() -> Vec<ScalarFunctionSignature> {
-        vec![ScalarFunctionSignature::exact(
-            vec![LogicalTypeId::Varchar.into()],
-            LogicalTypeId::Varchar.into(),
+    fn signatures() -> Vec<ArrowFunctionSignature> {
+        vec![ArrowFunctionSignature::exact(
+            vec![DataType::Utf8],
+            DataType::Utf8,
         )]
     }
 
@@ -232,9 +196,9 @@ impl VScalar for GeoipCountryIsoScalar {
 }
 
 impl GeoipCountryIsoScalar {
-    fn lookup_ip(db: &maxminddb::Reader<Mmap>, ip: String) -> Option<String> {
+    fn lookup_ip(db: &maxminddb::Reader<Mmap>, ip: IpAddr) -> Option<String> {
         match db
-            .lookup(ip.parse().ok()?)
+            .lookup(ip)
             .ok()
             .and_then(|result| result.decode::<geoip2::City>().ok())?
         {

--- a/test/sql/geoip_asn.test
+++ b/test/sql/geoip_asn.test
@@ -47,10 +47,10 @@ GB
 query TTTT
 SELECT geoip_asn_org('not_an_ip'),geoip_asn_num('not_an_ip'), geoip_city('not_an_ip'),geoip_country_iso('not_an_ip');
 ----
-(empty)
-(empty)
-(empty)
-(empty)
+NULL
+NULL
+NULL
+NULL
 
 statement error
 SELECT geoip_asn_org(1);


### PR DESCRIPTION

Use VArrowScalar instead of VScalar : remove unsafe code.
When value is not an IP, return Null instead of "".

Fixes #10 